### PR TITLE
rename logging, add saving timing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(
   VERSION 0.1.0
   LANGUAGES CXX)
 
-find_package(Boost REQUIRED COMPONENTS graph program_options)
+find_package(Boost REQUIRED COMPONENTS graph program_options log)
 
 find_package(Catch2 3 REQUIRED)
 include(CTest)
@@ -28,7 +28,7 @@ target_include_directories(
 target_link_libraries(mockup PUBLIC Boost::graph)
 
 add_executable(taskflow_demo bin/taskflow_demo.cpp)
-target_link_libraries(taskflow_demo PRIVATE Boost::program_options taskflow mockup )
+target_link_libraries(taskflow_demo PRIVATE Boost::program_options taskflow mockup Boost::log)
 
 add_executable(mockup_tests tests/read_graph.test.cpp)
 target_link_libraries(mockup_tests PRIVATE mockup Catch2::Catch2WithMain)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The project has following dependencies:
 - boost
     - program_options - used for the entry-point application
     - graph -  used when scheduling mockups workflows for reading workflow description stored in GraphML file
+    - log - used for configurable printouts
+
 ## Getting started
 
 Building:

--- a/bin/throughput.sh
+++ b/bin/throughput.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+WORKFLOW="$(dirname $0)/../data/ATLAS/q449/df.graphml"
+REPEAT=2
+AFFINITY=0
+THREADS_SEQ="2 4"
+
+THREADS_PER_SLOT=2
+EVENTS_PER_SLOT=2
+
+EXEC="$(dirname $0)/../build/taskflow_demo"
+
+for threads in ${THREADS_SEQ}; do
+    concurrent=$((threads/THREADS_PER_SLOT))
+    total=$((concurrent*EVENTS_PER_SLOT))
+    output_file="timing_${threads}.csv"
+    echo "Starting measurements for ${threads} threads, ${total} total events," \
+        "${concurrent} concurrent events"
+    CMD=(
+      numactl --cpunodebind="${AFFINITY}" --membind="${AFFINITY}" "${EXEC}" --dfg "${WORKFLOW}"
+      --threads="${threads}" --slots="${concurrent}" --event-count="${total}" --disable-logging
+      --trials="${REPEAT}" --save-timing="${output_file}"
+    )
+    CMD=${CMD[*]}
+    echo "Running command: ${CMD}"
+    $CMD
+done


### PR DESCRIPTION
Renaming `logs` related options to `trace`.
Adding running pipeline several times and saving timing results.
Adding a script to make a throughput scan